### PR TITLE
PLAT-1242 | Do not delete branches that may have a second open PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,11 @@ clean:
 .PHONY: build
 build: clean build-darwin build-linux
 
-build-%:
-	GOOS=$* GOARCH=386 go build -ldflags '${LDFLAGS}' -o ${PREFIX}${NAME}-$*
+build-linux:
+	GOOS=linux GOARCH=386 go build -ldflags '${LDFLAGS}' -o ${PREFIX}${NAME}-linux
+
+build-darwin:
+	GOOS=darwin GOARCH=amd64 go build -ldflags '${LDFLAGS}' -o ${PREFIX}${NAME}-darwin
 
 .PHONY: docker
 docker:

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func (ex *Executor) makeRequest(method string, url string) (res *http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Accept", "application/vnd.github.v3+json")
+
 	req.Header.Add("Authorization", "token "+ex.token)
 	res, _ = ex.client.Do(req)
 	if res.StatusCode >= 400 {
@@ -93,7 +93,7 @@ func (ex *Executor) listClosedPullRequests(user string, repo string, days int) (
 		res, err := ex.makeRequest("GET", "repos/"+user+"/"+repo+"/pulls?state=closed&sort=updated&direction=desc&per_page=100&page="+strconv.Itoa(page))
 
 		if err != nil {
-			return pullRequests, errors.New("failed to get pull requests (" + err.Error() + ")")
+			return pullRequests, errors.New("failed to get closed pull requests (" + err.Error() + ")")
 		}
 
 		d := json.NewDecoder(res.Body)
@@ -103,7 +103,7 @@ func (ex *Executor) listClosedPullRequests(user string, repo string, days int) (
 		err = d.Decode(&prs.PullRequests)
 
 		if err != nil {
-			return pullRequests, errors.New("failed to parse pull requests (" + err.Error() + ")")
+			return pullRequests, errors.New("failed to parse closed pull requests (" + err.Error() + ")")
 		}
 
 		for _, pr := range prs.PullRequests {
@@ -130,7 +130,7 @@ func (ex *Executor) listOpenPullRequests(user string, repo string) ([]pullReques
 		res, err := ex.makeRequest("GET", "repos/"+user+"/"+repo+"/pulls?state=open&sort=updated&direction=desc&per_page=100&page="+strconv.Itoa(page))
 
 		if err != nil {
-			return pullRequests, errors.New("failed to get pull requests (" + err.Error() + ")")
+			return pullRequests, errors.New("failed to get open pull requests (" + err.Error() + ")")
 		}
 
 		d := json.NewDecoder(res.Body)
@@ -140,7 +140,7 @@ func (ex *Executor) listOpenPullRequests(user string, repo string) ([]pullReques
 		err = d.Decode(&prs.PullRequests)
 
 		if err != nil {
-			return pullRequests, errors.New("failed to parse pull requests (" + err.Error() + ")")
+			return pullRequests, errors.New("failed to parse open pull requests (" + err.Error() + ")")
 		}
 
 		pullRequests = append(pullRequests, prs.PullRequests...)

--- a/main_test.go
+++ b/main_test.go
@@ -208,6 +208,28 @@ func TestRun(t *testing.T) {
 						"ref": "stalebranch",
 						"sha": "1761e021e70d29619ca270046b23bd243f652b98"
 					}
+				},
+				{
+					"number": 2,
+					"updated_at": "` + now.Format(time.RFC3339) + `",
+					"head": {
+						"ref": "notstalebranch",
+						"sha": "867530990210abcdefg867530990210abcdefg"
+					}
+				}
+				]`,
+		},
+		mockHTTPResponse{
+			method: "GET",
+			URL:    "/repos/user/repo/pulls?state=open&sort=updated&direction=desc&per_page=100&page=1",
+			body: `[
+				{
+					"number": 2,
+					"updated_at": "` + now.Format(time.RFC3339) + `",
+					"head": {
+						"ref": "notstalebranch",
+						"sha": "867530990210abcdefg867530990210abcdefg"
+					}
 				}
 				]`,
 		},


### PR DESCRIPTION
This addresses an edge case where multiple PRs can be associated with the same branch. If only one of these PRs is closed, the branch is mislabeled as stale, and incorrectly deleted. This PR adds an additional step which gathers a list of open PRs and removes the associated branches from the list of stale branches to delete.